### PR TITLE
Don't promisify this.request

### DIFF
--- a/src/google/api.js
+++ b/src/google/api.js
@@ -18,7 +18,7 @@ function CloudAPI (options) {
     packageJson: require('../../package.json')
   }
   this.projectId = options.projectId
-  this.asyncReq = util.promisify(this.request.bind(this))
+  this.asyncReq = this.request.bind(this)
   common.Service.call(this, config, options)
 }
 


### PR DESCRIPTION
The request method in the google-cloud is already designed to return a promise,
but detect for a callback.

https://github.com/googleapis/nodejs-common/blob/v0.20.3/src/service.ts#L235-L256