### PR TITLE
[feat] use warn to inform user error might be ok

### DIFF
--- a/src/google/api.js
+++ b/src/google/api.js
@@ -228,7 +228,8 @@ CloudAPI.prototype.getServiceAccount = function getServiceAccount (projectId, ac
       return result
     },
     err => {
-      log.error(`failed to get service account with ${err.message}`)
+      const msg = `Failed to get service account with ${err.message}. If this is a new service account, this error may be safely ignored.`
+      log.warn(msg)
       return undefined
     }
   )

--- a/src/google/provider.js
+++ b/src/google/provider.js
@@ -89,8 +89,8 @@ async function describeCluster (client, options) {
     log.info(`cluster status is ${cluster.status}`)
     return cluster
   } catch (e) {
-    const msg = `failed to get cluster details for project '${options.projectId}' cluster '${options.name}' with error: ${e.message}`
-    log.error(msg)
+    const msg = `failed to get cluster details for project '${options.projectId}' cluster '${options.name}' with error: ${e.message}. If this is a new cluster, this error may be safely ignored.`
+    log.warn(msg)
     return false
   }
 }


### PR DESCRIPTION
When you are provisioning a cluster kubeform will attempt to check to see
if the cluster already exists -- this results in an error if the cluster
is being made new.  The error it emits is ignorable in this case.

Switch the log level to warn to stop scaring people and insert text allowing
the operator to make the appropriate call given the scenario