### PR TITLE
(chore) use es6 Object.assign

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@google-cloud/storage": "^1.7.0",
     "bluebird": "^3.5.2",
     "bole": "^3.0.2",
-    "fauxdash": "^1.4.0",
     "inquirer": "^6.2.0",
     "joi": "^13.4.0",
     "js-yaml": "^3.12.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-const _ = require('fauxdash')
 const EventEmitter = require('events')
 const path = require('path')
 const fs = require('fs')
@@ -62,7 +61,7 @@ class API extends EventEmitter {
       }
     }
 
-    let mixed = _.merge(defaults, data, options.tokens || {})
+    let mixed = Object.assign(defaults, data, options.tokens || {})
     const missing = REQUIRED_FIELDS.reduce((missing, required) => {
       let obj = mixed
       if (required.indexOf('.')) {


### PR DESCRIPTION
No need to import all of fauxdash (which has a warning saying not to use
outside of personal projects), when all we need is an `Object.assign` statement