### PR TITLE
Fix crash when there are no enabled services

### DIFF
--- a/spec/google.api.spec.js
+++ b/spec/google.api.spec.js
@@ -610,5 +610,19 @@ describe('Google Cloud APIs', function () {
           .should.eventually.eql(['imaginary.googleapis.com'])
       })
     })
+
+    describe('and there are no enabled services', function () {
+      // Weirdly, Google's API returns a blank object with no services key!
+      before(function () {
+        scope.get(
+          '/projects/test-org/services?filter=state:ENABLED'
+        ).reply(200, JSON.stringify({}))
+      })
+
+      it('it should succeed', async function () {
+        await cloud.getEnabledServices('test-org')
+          .should.eventually.eql([])
+      })
+    })
   })
 })

--- a/src/google/api.js
+++ b/src/google/api.js
@@ -207,7 +207,7 @@ CloudAPI.prototype.getEnabledServices = function getEnabledServices (projectId) 
     method: 'GET',
     uri: `https://serviceusage.googleapis.com/v1/projects/${projectId}/services?filter=state:ENABLED`
   }).then(result => {
-    return result.services
+    return (result.services || [])
       .map(({name}) => name)
       .map(name => name.match(/\/([^/]+)$/)[1])
   })


### PR DESCRIPTION
When there are no enabled services, Google's API returns {} instead of
the expected {services:[]}.

This causes the provisioning to fail.